### PR TITLE
More tagging, more features =D

### DIFF
--- a/BaboKeywordPatcher/BaboKeywordPatcher.csproj
+++ b/BaboKeywordPatcher/BaboKeywordPatcher.csproj
@@ -1,12 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
+    <ImplicitUsings>true</ImplicitUsings>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mutagen.Bethesda" Version="0.31" />
-    <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.19.3" />
+    <PackageReference Include="Mutagen.Bethesda" Version="0.39.6" />
+    <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.24.1" />
+    <PackageReference Include="niflysharp" Version="1.3.0" />
   </ItemGroup>
 </Project>

--- a/BaboKeywordPatcher/SynthesisMeta.json
+++ b/BaboKeywordPatcher/SynthesisMeta.json
@@ -4,5 +4,13 @@
   "OneLineDescription": "",
   "LongDescription": "",
   "PreferredAutoVersioning": "Default",
-  "RequiredMods": []
+  "RequiredMods": [],
+  "TargetedReleases": [
+    "SkyrimLE",
+    "SkyrimSE",
+    "SkyrimVR",
+    "EnderalLE",
+    "EnderalSE",
+    "SkyrimSEGog"
+  ]
 }

--- a/BaboKeywordPatcher/TargetTypes/HdtHighHeelScript.cs
+++ b/BaboKeywordPatcher/TargetTypes/HdtHighHeelScript.cs
@@ -1,0 +1,50 @@
+﻿using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Synthesis;
+
+namespace BaboKeywordPatcher.TargetTypes
+{
+    internal class HdtHighHeelScript : TargetTypeBase
+    {
+        protected override string Name => "HdtHighHeel reader";
+
+        protected override bool IsValidType(IPatcherState<ISkyrimMod, ISkyrimModGetter> state)
+        {
+            if (state.LoadOrder.ContainsKey("hdtHighHeel.esm")) return true;
+
+            Console.WriteLine("'hdtHighHeel.esm' doeasnt exist! Exit..");
+            return false;            
+        }
+
+        protected override bool IsValidArmor()
+        {
+            // search if script added and valid
+            if (Armor!.VirtualMachineAdapter == null) return false;
+            if (Armor.VirtualMachineAdapter.Scripts == null) return false;
+            if (Armor.VirtualMachineAdapter.Scripts.Count == 0) return false;
+            var hhScriptEntrieGetter = Armor.VirtualMachineAdapter.Scripts.FirstOrDefault(sc => string.Equals(sc.Name, "hdthighheelshoes", StringComparison.InvariantCultureIgnoreCase));
+            if (hhScriptEntrieGetter == default) return false;
+            if (Program.Settings.Value.MinOffsetValue <= 0) return true; // dont need to check effect offset when it 0
+
+            // check effect offset
+            if (hhScriptEntrieGetter.Properties.Count != 1) return false; // must be 1 hh spell propety
+
+            var scriptProperty = hhScriptEntrieGetter.Properties[0];
+            if (scriptProperty is not ScriptObjectProperty objectProperty) return false;
+
+            var spellFormLink = objectProperty.Object;
+            if (!objectProperty.Object.TryResolve<ISpellGetter>(Program.LinkCache!, out var spellGetter)) return false;
+            if (spellGetter.Effects.Count != 1) return false; // must be one effect, maybe will change later
+
+            var offsetEffect = spellGetter.Effects[0];
+            if (offsetEffect.Data == null) return false; // effect data not set
+
+            if(offsetEffect.Data.Magnitude < Program.Settings.Value.MinOffsetValue) return false;
+
+            return true;
+        }
+
+        protected override bool IsValidArmorAddon() { return true; }
+    }
+}

--- a/BaboKeywordPatcher/TargetTypes/NifFile/ExtraDataTypes/IExtraDataTypeBase.cs
+++ b/BaboKeywordPatcher/TargetTypes/NifFile/ExtraDataTypes/IExtraDataTypeBase.cs
@@ -1,0 +1,10 @@
+﻿using nifly;
+using static nifly.niflycpp;
+
+namespace BaboKeywordPatcher.TargetTypes.NifFileTargetType.ExtraDataTypes
+{
+    public interface IExtraDataTypeBase
+    {
+        public bool IsValid(NiBlockRefNiExtraData extraDataRef, BlockCache blockCache);
+    }
+}

--- a/BaboKeywordPatcher/TargetTypes/NifFile/ExtraDataTypes/NIOHH.cs
+++ b/BaboKeywordPatcher/TargetTypes/NifFile/ExtraDataTypes/NIOHH.cs
@@ -1,0 +1,30 @@
+﻿using nifly;
+using static nifly.niflycpp;
+using System.Text.RegularExpressions;
+
+namespace BaboKeywordPatcher.TargetTypes.NifFileTargetType.ExtraDataTypes
+{
+    public class NIOHH : IExtraDataTypeBase
+    {
+        public bool IsValid(NiBlockRefNiExtraData extraDataRef, BlockCache blockCache)
+        {
+            var floatExtraData = blockCache.EditableBlockById<NiStringExtraData>(extraDataRef.index);
+            if (floatExtraData == null) return false;
+
+            using var name = floatExtraData.name;
+            using var value = floatExtraData.stringData;
+
+            if (name.get() != "SDTA") return false; // check if HH_OFFSET
+
+            Match match = Regex.Match(value.get(), @"\[{\""name\"":\s*\""NPC\"",\s*\""pos\"":\s*\[0,\s*0,\s*([0-9\.]+)\]}\]");
+            if (!match.Success) return false; // check if success found json string for offset value
+            if (Program.Settings.Value.MinOffsetValue <= 0) return true; // dont need to check effect offset when it 0
+            
+            if (!float.TryParse(match.Groups[1].Value.Replace('.', ','), out var offset)) return false;
+
+            if (offset < Program.Settings.Value.MinOffsetValue) return false; // check if valid offset value
+
+            return true;
+        }
+    }
+}

--- a/BaboKeywordPatcher/TargetTypes/NifFile/ExtraDataTypes/RMHH.cs
+++ b/BaboKeywordPatcher/TargetTypes/NifFile/ExtraDataTypes/RMHH.cs
@@ -1,0 +1,22 @@
+﻿using nifly;
+using static nifly.niflycpp;
+
+namespace BaboKeywordPatcher.TargetTypes.NifFileTargetType.ExtraDataTypes
+{
+    public class RMHH : IExtraDataTypeBase
+    {
+        public bool IsValid(NiBlockRefNiExtraData extraDataRef, BlockCache blockCache)
+        {
+            var floatExtraData = blockCache.EditableBlockById<NiFloatExtraData>(extraDataRef.index);
+            if (floatExtraData == null) return false;
+
+            using var name = floatExtraData.name;
+
+            if (name.get() != "HH_OFFSET") return false; // check if HH_OFFSET
+            if (Program.Settings.Value.MinOffsetValue <= 0) return true; // dont need to check effect offset when it 0
+            if (floatExtraData.floatData < Program.Settings.Value.MinOffsetValue) return false; // check if valid offset value
+
+            return true;
+        }
+    }
+}

--- a/BaboKeywordPatcher/TargetTypes/NifFile/NifFile.cs
+++ b/BaboKeywordPatcher/TargetTypes/NifFile/NifFile.cs
@@ -1,0 +1,34 @@
+﻿using Mutagen.Bethesda;
+using Mutagen.Bethesda.Skyrim;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BaboKeywordPatcher.TargetTypes.NifFileTargetType.Tools;
+
+namespace BaboKeywordPatcher.TargetTypes.NifFileTargetType
+{
+    internal class NifFile : TargetTypeBase
+    {
+        protected override string Name => "Nif extradata reader";
+
+        protected override bool IsValidArmor() { return true; }
+
+        protected override bool IsValidArmorAddon()
+        {
+            if (ArmorAddon!.WorldModel == null) return false;
+            if (ArmorAddon.WorldModel.Female == null) return false;
+
+            var fileSubPath = ArmorAddon.WorldModel.Female.File;
+            if (string.IsNullOrWhiteSpace(fileSubPath)) return false;
+
+            var filePath = Data!.State!.DataFolderPath + "\\meshes\\" + fileSubPath;
+            if (!File.Exists(filePath)) return false;
+
+            if (NiflyTools.IsFoundValidMarker(filePath)) return true;
+
+            return false;
+        }
+    }
+}

--- a/BaboKeywordPatcher/TargetTypes/NifFile/Tools/NiflyTools.cs
+++ b/BaboKeywordPatcher/TargetTypes/NifFile/Tools/NiflyTools.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using nifly;
+using BaboKeywordPatcher.TargetTypes.NifFileTargetType.ExtraDataTypes;
+using static nifly.niflycpp;
+
+namespace BaboKeywordPatcher.TargetTypes.NifFileTargetType.Tools
+{
+    public class NiflyTools
+    {
+        static readonly List<IExtraDataTypeBase> CheckersList = new()
+        {
+            new NIOHH(),
+            new RMHH(),
+        };
+
+        // examples of using: https://github.com/SteveTownsend/AllGUDMeshGen
+        public static bool IsFoundValidMarker(string filePath)
+        {
+            var nifFile = new nifly.NifFile();
+            var loadResult = nifFile.Load(filePath, new NifLoadOptions { isTerrain = false });
+            if (loadResult != 0) return false; // nif cant be loaded
+
+            var blockCache = new BlockCache(nifFile.GetHeader());
+            var shapes = nifFile.GetShapes();
+            foreach (var shape in shapes)
+            {
+                foreach (var extraDataRef in shape.extraDataRefs.GetRefs())
+                {
+                    using (extraDataRef)
+                    {
+                        if (extraDataRef.IsEmpty()) continue;
+
+                        foreach (var checker in CheckersList) if (checker.IsValid(extraDataRef, blockCache)) return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/BaboKeywordPatcher/TargetTypes/TargetTypeBase.cs
+++ b/BaboKeywordPatcher/TargetTypes/TargetTypeBase.cs
@@ -1,0 +1,54 @@
+﻿using Mutagen.Bethesda;
+using Mutagen.Bethesda.Plugins;
+using Mutagen.Bethesda.Skyrim;
+using Mutagen.Bethesda.Synthesis;
+
+namespace BaboKeywordPatcher.TargetTypes
+{
+    public class TargetTypeData
+    {
+        public IPatcherState<ISkyrimMod, ISkyrimModGetter>? State;
+        public FormKey HighHeelSoundFormKey;
+    }
+
+    public abstract class TargetTypeBase
+    {
+        protected TargetTypeData? Data;
+        bool IsValid = false;
+
+        public bool SetIsValid(IPatcherState<ISkyrimMod, ISkyrimModGetter> state) { return IsValid = IsValidType(state); }
+
+        protected virtual bool IsValidType(IPatcherState<ISkyrimMod, ISkyrimModGetter> state) { return true; }
+
+        public void SetInputData(TargetTypeData data) { Data = data; }
+
+        // These are just globals with extra steps.
+        // They are only valid for the duration of a call to IsFound.
+        // OO was mistake, lol.
+        protected IArmorAddonGetter? ArmorAddon;
+        protected IArmorGetter? Armor;
+
+        protected abstract string Name { get; }
+        public bool IsFound(IArmorGetter? armor, IArmorAddonGetter? arma)
+        {
+            if (!IsValid) return false;
+
+            if (armor == null) return false;
+            Armor = armor;
+
+            if (!IsValidArmor() 
+                || Armor.Armature == null 
+                || (Armor.TemplateArmor!=null && !Armor.TemplateArmor.IsNull)) // all templated have same armor addon
+                return false;
+
+            ArmorAddon = arma;
+
+            if (ArmorAddon == null || !IsValidArmorAddon()) return false;
+
+            return true;
+        }
+
+        protected abstract bool IsValidArmor();
+        protected abstract bool IsValidArmorAddon(); 
+    }
+}


### PR DESCRIPTION
I've been hacking on this for a few days, and I'm pretty happy with the results so I figured I'd share. That said, I did touch an awful lot for a single PR, so my apologies for that. As with the PR from the other contributor, don't feel obligated to take anything.

Features include:
* Flagging of female only armor (with SLA_ArmorFemaleOnly) and then, in turn, allowing config options for setting defaults of pretty or erotic to only apply to those items.
  *  This works by checking for missing or vanilla male world models on the arma record when the female world model is custom.
* Tagging of high heels using the same method as SynHeelsSoundFix (specifically, by looking at NIF metadata or scripts atttached to the shoe).
* A config option to tag chokers as collars 
* A bunch of non-Babo keywords, including OCF (and by extension FG), SexLabNoStrip, ZaZ, ClothingHH from the "Conditional High Heels" suite of mods,  Plus some random mods (the ones I happened to be planning to test when I started hacking on this), specifically (NoticeMeSenpai, MistySkye, LichEvilynn).
* You can now run the patcher without all the keyword sources, it'll just ignore keywords from sources you don't have.
* Application of keywords more closely adheres to the advice include with BaboDialogue.
  * Some are only intended to apply to Body slot (32) items (SLA_ArmorHalfNakedBikini, SLA_ArmorLewdLeotard, SLA_ArmorRubber, SLA_ArmorSpandex, EroticArmor, SLA_ArmorPretty).
  * Armor can be tagged rubber but it will also be tagged spandex.
  * Detection of underwear and trousers also limits using slots (52, 49 and 45). "Pants" no longer matches as underwear as all armor mods that I've checked use the American meaning.
  * Detection of heels only applies to foot slot item.
 * Specific tag additions:
   * SLA_ArmorLewdLeotard from "leotard"
   * SLA_ArmorRubber from "ebonite", "rubber", "latex"
   * SLA_MicroHotpants from "short pants"
   * ClothingPanties added to anything classed as SLA_PantiesNormal, SLA_ThongT, SLA_ThongGstring, SLA_ThongCstring, 
SLA_ThongLowleg
   * SLA_PantsNormal from "pants", "trousers"
   * SLA_KillerHeels added to things classed as heels that don't have "boots" in the label
   * ClothingPoor, _T_BeggarClothes from  "beggar", "ragged", "prisoner", "roughspun", "vagabond"
   * ClothingPoor is also added when _T_BeggarClothes is found
   * SLA_ArmorCapeFull from "cape" or "cloak", but not "stormcloak"
   * zbfWornCollar from "collar" and, if you turn it on, "choker"
   * zbfWornYoke from "yoke"
   * ClothingStrapOn from "strapon", also adds SexLabNoStrip
   * zbfWornBra, ClothingBra are added where SLA_BraArmor was added
   * SLA_PelvicCurtain from "loincloth"
   * SLA_ShowgirlSkirt, from "skirt" and "showgirl"
   * SLA_MicroSkirt from "skirt" and "micro"
   * SLA_FullSkirt from "skirt" and none  of the others
   * zbfWornBra, ClothingBra are added to things tagged SLA_BraArmor
   * SLA_ArmorPartTop is added to any item detected as a bra
   * SLA_ArmorPartBottom is added to any item detected as underwear, pants or hotpants
   * SexLabNoStrip, LE_NoStrip are each added when the other is found, they're also added when ClothingStrapOn is found
   * zbfWornDevice is added when zbfWornCollar is found
   * SLA_ArmorBondage is added when zbfWornDevice 
   * zbfEffectNoSprint, zbfEffectSlowMove, zbfWornAnkles are added when zbfWornDevice is found and the item goes in the foot slot
   * ClothingHH is added when SLA_BootsHeels or SLA_KillerHeels is found
   * SLA_ArmorSpandex is added when SLA_ArmorRubber is found
   * EroticArmor is added when SLA_ArmorHalfNakedBikini, SLA_ArmorLewdLeotard, SLA_ArmorSpandex are found
     * In theory EroticArmor is supposed to be mutually exclusive with those tags, but EroticArmor is way more widely supported so there's a lot of value in adding it.
     * MSCoverage is added when SLA_ArmorPartBottom is found and vice versa
     * MSTopOnly is added when SLA_ArmorPartTop is found (and SLA_ArmorPartBottom is not found) and vice versa
 * Specific tag changes:
   * SLA_ArmorHarness is now not added if the item is tagged zbfWornGag or has "gag" or "collar" in the label.
   * SLA_ArmorTransparent now does not tag items with TRX in their label.
   * SLA_VaginalDildo now matches on "plug", "dildo", "vibrator" but only if "anal" or "butt" are not found.
   * SLA_AnalPlug conversly, is only added when ALL of those are found.
   * SLA_MiniSkirt now only matches for "mini" and "skirt"

Things I'll add one of these days:
* More ZaZ tags, more mods with interesting or useful tags, kinda moving in the direction of being a general armor tagger
* Config option to default Skirts to various types. For instance, you may only have miniskirts, so any mention of "skirt" should be mini unless otherwise noted.